### PR TITLE
Fix PWA cache list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Workout Tracker",
   "short_name": "Workout",
-  "start_url": "index.html",
+  "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#1f1f1f",
   "theme_color": "#2d2d2d",

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,7 +5,8 @@ self.addEventListener('install', event => {
         'index.html',
         'style.css',
         'app.js',
-        'manifest.json'
+        'manifest.json',
+        '185-1851780_cartman-beefcake-eric-cartman-beefcake.png'
       ]);
     })
   );

--- a/style.css
+++ b/style.css
@@ -104,6 +104,7 @@ li button:hover {
 .custom-field-row input[type="checkbox"] {
   margin: 0;
   transform: scale(1.2);
+  width: auto;
 }
 
 


### PR DESCRIPTION
## Summary
- precache the icon in `service-worker.js`
- use a relative start URL in `manifest.json`
- align new exercise checkboxes and labels

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684b358aff6883318044befbb99e1afb