### PR TITLE
Fix label text in renderPlan

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,7 +49,7 @@ function renderPlan() {
   container.innerHTML = `
     <h2>Log a New Exercise</h2>
     <form class="exercise-log-form" id="exercise-form">
-      <label for="exercise-select">Select Exercise (tap to reveal the exercist list):</label>
+      <label for="exercise-select">Select Exercise (tap to reveal the exercise list):</label>
       <select id="exercise-select">
         ${Object.keys(getAllExercises()).map(e => `<option value="${e}">${e}</option>`).join('')}
       </select><br>


### PR DESCRIPTION
## Summary
- correct wording of exercise selection label in `renderPlan`

## Testing
- `npm test` *(fails: Could not find package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c7472d5c48331ae1a0ad6181f6fc1