### PR TITLE
Enable editing custom exercise video links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a simple progressive web application (PWA) for tracking workouts. It run
 - Edit and delete previously saved logs.
 - Custom exercises with selectable fields such as weight, reps and time, and an optional demonstration video link.
 - Optional video links for each exercise.
+- Edit or remove video links for custom exercises.
 - Offline support via a service worker.
 
 ## Usage

--- a/app.js
+++ b/app.js
@@ -174,6 +174,19 @@ function renderAddExerciseForm() {
   };
 }
 
+function editCustomExerciseVideo(name) {
+  const current = customExerciseVideos[name] || '';
+  const url = prompt(`Edit video URL for ${name}:`, current);
+  if (url === null) return; // cancelled
+  if (url.trim()) {
+    customExerciseVideos[name] = url.trim();
+  } else {
+    delete customExerciseVideos[name];
+  }
+  localStorage.setItem('customExerciseVideos', JSON.stringify(customExerciseVideos));
+  generateSetInputs();
+}
+
 function generateSetInputs() {
   const select = document.getElementById('exercise-select');
   const countInput = document.getElementById('set-count');
@@ -182,7 +195,16 @@ function generateSetInputs() {
   const videoLink = document.getElementById('video-link');
   if (videoLink) {
     const url = getExerciseVideo(select.value);
-    videoLink.innerHTML = url ? `<a href="${url}" target="_blank">Exercise Demonstration Video</a>` : '';
+    const isCustom = !!customExercises[select.value];
+    let html = url ? `<a href="${url}" target="_blank">Exercise Demonstration Video</a>` : '';
+    if (isCustom) {
+      html += ` <button type="button" id="edit-video-btn">Edit Video URL</button>`;
+    }
+    videoLink.innerHTML = html;
+    if (isCustom) {
+      const btn = document.getElementById('edit-video-btn');
+      if (btn) btn.onclick = () => editCustomExerciseVideo(select.value);
+    }
   }
 
   const count = parseInt(countInput.value);


### PR DESCRIPTION
## Summary
- allow editing/removing video links for custom exercises
- show Edit Video URL button when a custom exercise is selected
- document the ability to edit custom video links

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_684c747778388331a11db7967870ee87