### PR TITLE
Fix set count field refresh issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,8 +118,8 @@ function renderPlan() {
   };
 
   generateSetInputs();
-  document.getElementById('set-count').addEventListener('input', generateSetInputs);
-  document.getElementById('exercise-select').addEventListener('change', generateSetInputs);
+  document.getElementById('set-count').addEventListener('input', () => generateSetInputs());
+  document.getElementById('exercise-select').addEventListener('change', () => generateSetInputs());
   document.getElementById('edit-video-link').addEventListener('click', editVideoLink);
 }
 


### PR DESCRIPTION
## Summary
- ensure set input fields update when changing set count or exercise selection

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c998b19b483318c96440863a26fcd