### PR TITLE
Add light theme and bottom navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a simple progressive web application (PWA) for tracking workouts. It run
 - Log workouts with multiple sets for built‑in or custom exercises.
 - Edit and delete previously saved logs.
 - Bottom navigation menu for **Log**, **History**, and **Settings**.
+- Modern light color palette for a clean look.
 - Custom exercises with selectable fields such as weight, reps and time, and an optional demonstration video link.
 - Rename and manage custom exercises after creation.
 - Export or import workout logs and custom exercises for backup.

--- a/app.js
+++ b/app.js
@@ -443,10 +443,39 @@ function clearAllLogs() {
   }
 }
 
+function showSection(section) {
+  const sections = {
+    log: document.getElementById('workout-plan'),
+    history: document.getElementById('log-history'),
+    settings: document.getElementById('settings')
+  };
+  Object.entries(sections).forEach(([key, el]) => {
+    if (el) el.style.display = key === section ? 'block' : 'none';
+  });
+
+  const buttons = {
+    log: document.getElementById('nav-log'),
+    history: document.getElementById('nav-history'),
+    settings: document.getElementById('nav-settings')
+  };
+  Object.entries(buttons).forEach(([key, btn]) => {
+    if (btn) btn.classList.toggle('active', key === section);
+  });
+}
+
 window.onload = () => {
   getOrAskName();
   renderPlan();
   renderLogs();
+
+  showSection('log');
+
+  const navLog = document.getElementById('nav-log');
+  const navHistory = document.getElementById('nav-history');
+  const navSettings = document.getElementById('nav-settings');
+  if (navLog) navLog.onclick = () => { showSection('log'); renderPlan(); };
+  if (navHistory) navHistory.onclick = () => { showSection('history'); renderLogs(); };
+  if (navSettings) navSettings.onclick = () => { showSection('settings'); };
 
   const exportBtn = document.getElementById('export-logs');
   if (exportBtn) exportBtn.onclick = exportLogs;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="theme-color" content="#2d2d2d" />
+  <meta name="theme-color" content="#6366f1" />
   <link rel="manifest" href="manifest.json" />
   <link rel="stylesheet" href="style.css" />
   <title>Workout Tracker</title>
@@ -27,6 +27,12 @@
       <button id="clear-logs">Clear All Logs</button>
     </div>
   </div>
+
+  <nav class="bottom-nav">
+    <button id="nav-log" class="active">Log a New Exercise</button>
+    <button id="nav-history">Workout History</button>
+    <button id="nav-settings">Settings</button>
+  </nav>
   <script src="app.js"></script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
   "short_name": "Workout",
   "start_url": "./index.html",
   "display": "standalone",
-  "background_color": "#1f1f1f",
-  "theme_color": "#2d2d2d",
+  "background_color": "#f6f7f9",
+  "theme_color": "#6366f1",
   "icons": [
     {
       "src": "185-1851780_cartman-beefcake-eric-cartman-beefcake.png",

--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
 /* === Base Styling === */
 body {
-  font-family: sans-serif;
-  background-color: #1f1f1f;
-  color: #ffffff;
+  font-family: Arial, Helvetica, sans-serif;
+  background-color: #f6f7f9;
+  color: #333;
   margin: 0;
   padding: 0;
 }
@@ -11,10 +11,11 @@ body {
   padding: 2rem;
   max-width: 800px;
   margin: auto;
+  padding-bottom: 5rem; /* space for nav */
 }
 
 h1, h2, h3 {
-  color: #facc15;
+  color: #2563eb;
 }
 
 /* === Form Elements === */
@@ -24,15 +25,15 @@ textarea, input, select {
   margin-top: 0.5rem;
   margin-bottom: 1rem;
   font-size: 1rem;
-  border: none;
+  border: 1px solid #ccc;
   border-radius: 5px;
-  background-color: #2d2d2d;
-  color: #fff;
+  background-color: #fff;
+  color: #333;
   box-sizing: border-box;
 }
 
 button {
-  background-color: #10b981;
+  background-color: #6366f1;
   color: #fff;
   border: none;
   padding: 0.5rem 1rem;
@@ -42,7 +43,7 @@ button {
 }
 
 button:hover {
-  background-color: #059669;
+  background-color: #4f46e5;
 }
 
 /* === List Styling === */
@@ -54,7 +55,8 @@ ul {
 li {
   margin-bottom: 0.5rem;
   padding: 0.5rem;
-  background-color: #2d2d2d;
+  background-color: #fff;
+  border: 1px solid #ddd;
   border-radius: 5px;
 }
 
@@ -85,7 +87,7 @@ li button:hover {
 /* === Toggle Button === */
 .toggle-button {
   background: none;
-  color: #facc15;
+  color: #2563eb;
   border: none;
   font-weight: bold;
   cursor: pointer;
@@ -98,7 +100,7 @@ li button:hover {
   align-items: center;
   gap: 10px;
   margin-bottom: 8px;
-  color: #fff;
+  color: #333;
 }
 
 .custom-field-row input[type="checkbox"] {
@@ -111,7 +113,7 @@ li button:hover {
 
 /* === Set Input Blocks === */
 .set-input {
-  background-color: #333;
+  background-color: #f0f0f0;
   padding: 0.5rem;
   margin-bottom: 1rem;
   border-radius: 5px;
@@ -143,7 +145,7 @@ li button:hover {
 
 /* === Video Link === */
 #video-link a {
-  background-color: #10b981;
+  background-color: #6366f1;
   color: #fff;
   padding: 0.5rem 1rem;
   border-radius: 5px;
@@ -152,7 +154,7 @@ li button:hover {
 }
 
 #edit-video-link {
-  color: #fff;
+  color: #2563eb;
   text-decoration: underline;
   background: none;
   border: none;
@@ -168,4 +170,35 @@ li button:hover {
 #settings input[type="file"] {
   margin-top: 0.5rem;
   margin-bottom: 1rem;
+}
+
+#log-history,
+#settings {
+  display: none;
+}
+
+/* === Bottom Navigation === */
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: #ffffff;
+  border-top: 1px solid #ddd;
+  display: flex;
+  justify-content: space-around;
+  padding: 0.5rem 0;
+}
+
+.bottom-nav button {
+  background: none;
+  border: none;
+  color: #2563eb;
+  font-size: 1rem;
+  flex: 1;
+}
+
+.bottom-nav button.active {
+  font-weight: bold;
+  border-bottom: 2px solid #2563eb;
 }


### PR DESCRIPTION
## Summary
- modernize color palette
- implement bottom navigation for log/history/settings
- hide history and settings until selected
- update manifest and README

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687e9f63b768833187766625406eac12