### PR TITLE
Improve time inputs, backups, and service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <div id="settings">
       <h2>⚙️ Settings</h2>
       <label>Import from Backup: <input type="file" id="import-backup" accept="application/json"></label>
+      <button type="button" id="download-backup-button">Download Backup</button>
       <button type="button" id="update-app-button">Update App</button>
     </div>
   </div>

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,8 +4,7 @@ const PRECACHE_URLS = [
   'index.html',
   'style.css',
   'app.js',
-  'manifest.json',
-  '185-1851780_cartman-beefcake-eric-cartman-beefcake.png'
+  'manifest.json'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- store exercise time inputs as separate minute and second values and show them in logs
- add a manual download backup button and stop triggering automatic downloads on every change
- remove the missing precache asset from the service worker to restore install success

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6b57970fc8331bc6e4410090aeacf